### PR TITLE
[IMPORTANT] Improve Result interface

### DIFF
--- a/common/result.h
+++ b/common/result.h
@@ -12,25 +12,20 @@ public:
   Result(T t) : _t(t), _error(false) {
   }
   ~Result() {
-    if (!_checked) {
+    if (_error && !_checked) {
       panic("Result: error: check the result\n");
     }
   }
   T Unwrap() {
-    _checked = true;
     if (_error) {
       panic("Result: error: failed to unwrap\n");
     }
+    _checked = true;
     return _t;
   }
   bool IsError() {
-    return _error;
-  }
-  void IgnoreError() {
-    if (!_error) {
-      panic("Result: error: do not call IgnoreError() when there is no error.\n");
-    }
     _checked = true;
+    return _error;
   }
 private:
   T _t;

--- a/common/tests/Makefile
+++ b/common/tests/Makefile
@@ -1,10 +1,16 @@
-SRC:=main.cc align.cc channel_accessor.cc mock/channel.cc mock/debug.cc #result.cc memrw.cc 
+include ../../hakase/build_rule.mk
+
+ifeq ($(HOST),)
+
+SRC:=main.cc align.cc channel_accessor.cc result.cc mock/channel.cc mock/debug.cc # memrw.cc  channel.cc
 
 .PHONY: test clean
 
 test: $(SRC)
-	g++ $(SRC) --std=c++14 --coverage -iquote mock -I mock -iquote /share/ -iquote /share/hakase/ -I/cpputest/include -L/cpputest/lib -lCppUTest -lCppUTestExt
-	./a.out -c
+	g++ $(SRC) --std=c++14 --coverage -iquote mock -I mock -iquote /share/ -iquote /share/hakase/ -I/cpputest/include -L/cpputest/lib -lCppUTest -lCppUTestExt -pthread
+	./a.out -c -v
 
 clean:
 	rm -f ./a.out *.gcov *.gcda *.gcno
+
+endif

--- a/common/tests/result.cc
+++ b/common/tests/result.cc
@@ -1,9 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockSupport.h"
 
-#define panic(x) panic_mock(x)
-void panic_mock(const char *);
-
 #include "../result.h"
 
 TEST_GROUP(Result) {
@@ -15,24 +12,38 @@ TEST_GROUP(Result) {
   }
 };
 
-
-// must IgnoreError() after you finished error handling
-TEST(Result, IgnoreWhenError) {
+TEST(Result, Error) {
   mock().expectNoCall("panic");
   {
     Result<bool> r;
     CHECK(r.IsError());
-    r.IgnoreError();
   }
   mock().checkExpectations();
 }
 
-// must Unwrap() when noerror
-TEST(Result, UnwrapWhenNoError) {
+TEST(Result, NoError) {
   mock().expectNoCall("panic");
   {
     Result<bool> r(true);
     CHECK_FALSE(r.IsError());
+  }
+  mock().checkExpectations();
+}
+
+// must check result
+TEST(Result, IgnoreWhenError) {
+  mock().expectNoCall("panic");
+  {
+    Result<bool> r;
+    r.IsError();
+  }
+  mock().checkExpectations();
+}
+
+TEST(Result, AbleToUnwrapWhenNoError) {
+  mock().expectNoCall("panic");
+  {
+    Result<bool> r(true);
     r.Unwrap();
   }
   mock().checkExpectations();
@@ -47,18 +58,7 @@ TEST(Result, UnwrapWhenError) {
   mock().expectOneCall("panic");
   {
     Result<bool> r;
-    CHECK(r.IsError());
     r.Unwrap();
-  }
-  mock().checkExpectations();
-}
-
-// must check result
-TEST(Result, NotcheckedWhenNoError) {
-  mock().expectOneCall("panic");
-  {
-    Result<bool> r(true);
-    CHECK_FALSE(r.IsError());
   }
   mock().checkExpectations();
 }
@@ -68,19 +68,6 @@ TEST(Result, NotcheckedWhenError) {
   mock().expectOneCall("panic");
   {
     Result<bool> r;
-    CHECK(r.IsError());
   }
   mock().checkExpectations();
 }
-
-// do not IgnoreError() when noerror
-TEST(Result, IgnoreWhenNoErrror) {
-  mock().expectOneCall("panic");
-  {
-    Result<bool> r(true);
-    CHECK_FALSE(r.IsError());
-    r.IgnoreError();
-  }
-  mock().checkExpectations();
-}
-

--- a/hakase/elf_loader/test/hakase.cc
+++ b/hakase/elf_loader/test/hakase.cc
@@ -11,33 +11,18 @@ int test_main(F2H &f2h, H2F &h2f, I2H &i2h, int argc, const char **argv) {
     return 1;
   }
 
-  {
-    auto r = file->Init(h2f);
-    if (r.IsError()) {
-      r.IgnoreError();
-      return 1;
-    }
-    r.Unwrap();
+  if (file->Init(h2f).IsError()) {
+    return 1;
   }
   
   ElfLoader sl(h2f, std::move(file));
 
-  {
-    auto r = sl.Deploy();
-    if (r.IsError()) {
-      r.IgnoreError();
-      return 1;
-    }
-    r.Unwrap();
+  if (sl.Deploy().IsError()) {
+    return 1;
   }
 
-  {
-    auto r = sl.Execute(1);
-    if (r.IsError()) {
-      r.IgnoreError();
-      return 1;
-    }
-    r.Unwrap();
+  if (sl.Execute(1).IsError()) {
+    return 1;
   }
 
   int16_t type;

--- a/hakase/interrupt/test/hakase.cc
+++ b/hakase/interrupt/test/hakase.cc
@@ -16,33 +16,18 @@ int test_main(F2H &f2h, H2F &h2f, I2H &i2h, int argc, const char **argv) {
     return 1;
   }
 
-  {
-    auto r = file->Init(h2f);
-    if (r.IsError()) {
-      r.IgnoreError();
-      return 1;
-    }
-    r.Unwrap();
+  if (file->Init(h2f).IsError()) {
+    return 1;
   }
 
   ElfLoader sl(h2f, std::move(file));
 
-  {
-    auto r = sl.Deploy();
-    if (r.IsError()) {
-      r.IgnoreError();
-      return 1;
-    }
-    r.Unwrap();
+  if (sl.Deploy().IsError()) {
+    return 1;
   }
 
-  {
-    auto r = sl.Execute(1);
-    if (r.IsError()) {
-      r.IgnoreError();
-      return 1;
-    }
-    r.Unwrap();
+  if (sl.Execute(1).IsError()) {
+    return 1;
   }
 
   for (int i = 0; i < 33; i++) {

--- a/hakase/simple_loader/test/hakase.cc
+++ b/hakase/simple_loader/test/hakase.cc
@@ -14,11 +14,9 @@ int test_main(F2H &f2h, H2F &h2f, I2H &i2h, int argc, const char **argv) {
 
   SimpleLoader sl(h2f, std::move(file));
 
-  auto r = sl.Deploy();
-  if (r.IsError()) {
+  if (sl.Deploy().IsError()) {
     return 1;
   }
-  r.Unwrap();
 
   ChannelAccessor<> ch_ac(h2f, 3);
   ch_ac.Write<uint64_t>(0, kDeployAddressStart);


### PR DESCRIPTION
Resultインターフェースの変更
* IgonoreError()は破棄
* IsError()さえ呼んでおけば、エラー時もOK

使い方はこんな感じ
https://github.com/PFLab-OS/Toshokan/blob/9573c663df58fcd06f0d4e05b9315e5b1b1a74f1/common/tests/result.cc#L34-L50