### PR TITLE
0クリア用インターフェース実装

### DIFF
--- a/hakase/FriendLoader/debug_mem.c
+++ b/hakase/FriendLoader/debug_mem.c
@@ -71,23 +71,23 @@ static ssize_t zero_clear_write(struct file *file, const char __user *buf, size_
   char buf_tmp[256];
 
   if(zero_clear_status != 0) {
-    return len;
+    return -EINVAL;
   }
 
   snprintf(buf_tmp, min(len+1, 256), "%s", buf);
 
   if(kstrtouint(buf_tmp, 10, &tmp) != 0) {
-    return len;
+    return -EINVAL;
   }
 
   if(tmp > (DEPLOY_PHYS_MEM_SIZE / PAGE_SIZE) ) {
-    return len;
+    return -EINVAL;
   }
 
   zero_clear_status = tmp;
   schedule_work(&zero_clear_workq);
 
-  return 1;
+  return len;
 
 }
 

--- a/hakase/FriendLoader/debug_mem.c
+++ b/hakase/FriendLoader/debug_mem.c
@@ -1,4 +1,6 @@
 #include <linux/debugfs.h>
+#include <linux/kernel.h>
+#include <linux/workqueue.h>
 #include <linux/slab.h>
 #include <asm/io.h>
 #include <asm/dma.h>
@@ -7,6 +9,12 @@
 
 static struct dentry *topdir;
 static struct dentry *memory;
+static struct dentry *zero_clear;
+
+//TODO using lock 
+static unsigned int zero_clear_status = 0;
+
+struct work_struct zero_clear_workq;
 
 static ssize_t memory_read(struct file *file, char __user *buf, size_t len, loff_t *ppos) {
   void __iomem *io_addr;
@@ -49,10 +57,64 @@ static loff_t memory_llseek(struct file *file, loff_t offset, int origin) {
   return offset;
 }
 
+static ssize_t zero_clear_read(struct file *file, char __user *buf, size_t len, loff_t *ppos) {
+  if(*ppos != 0) {
+    return 0;
+  }
+  snprintf(buf, len, "%u", zero_clear_status);
+  *ppos = strlen(buf) + 1;
+  return strlen(buf) + 1; 
+}
+
+static ssize_t zero_clear_write(struct file *file, const char __user *buf, size_t len, loff_t *ppos) {
+  unsigned int tmp;
+  char buf_tmp[256];
+
+  if(zero_clear_status != 0) {
+    return len;
+  }
+
+  snprintf(buf_tmp, min(len+1, 256), "%s", buf);
+
+  if(kstrtouint(buf_tmp, 10, &tmp) != 0) {
+    return len;
+  }
+
+  if(tmp > (DEPLOY_PHYS_MEM_SIZE / PAGE_SIZE) ) {
+    return len;
+  }
+
+  zero_clear_status = tmp;
+  schedule_work(&zero_clear_workq);
+
+  return 1;
+
+}
+
+void memory_zero_clear(struct work_struct *work) {
+  void __iomem *io_addr;
+  int i;
+
+  for(i = 0; i < zero_clear_status; i++) {
+    io_addr = ioremap(DEPLOY_PHYS_ADDR_START + PAGE_SIZE*i, PAGE_SIZE);
+    memset(io_addr, 0, PAGE_SIZE);
+    iounmap(io_addr);
+  }
+
+  zero_clear_status = 0;
+  return;
+}
+
 static struct file_operations memory_fops = {
   .owner = THIS_MODULE,
   .read = memory_read,
   .llseek = memory_llseek,
+};
+
+static struct file_operations zero_clear_fops = {
+  .owner = THIS_MODULE,
+  .read = zero_clear_read,
+  .write = zero_clear_write,
 };
 
 int __init debugmem_init(void) {
@@ -65,6 +127,13 @@ int __init debugmem_init(void) {
   if (!memory) {
     return -ENOMEM;
   }
+
+  zero_clear = debugfs_create_file("zero_clear", 0400, topdir, NULL, &zero_clear_fops);
+  if (!zero_clear) {
+    return -ENOMEM;
+  }
+
+  INIT_WORK(&zero_clear_workq, memory_zero_clear);
 
   return 0;
 }

--- a/hakase/tests/test_hakase.sh
+++ b/hakase/tests/test_hakase.sh
@@ -4,6 +4,10 @@
 
 cd `dirname $0`
 if [ -f $1 ]; then
+    ./run.sh load
+
+    echo 10000 | sudo tee /sys/kernel/debug/friend_loader/zero_clear
+
     ./run.sh run
 
     trap './run.sh stop;' SIGINT

--- a/hakase/tests/test_hakase.sh
+++ b/hakase/tests/test_hakase.sh
@@ -8,6 +8,12 @@ if [ -f $1 ]; then
 
     echo 10000 | sudo tee /sys/kernel/debug/friend_loader/zero_clear
 
+    zc=""
+    while [ "$zc" != "0" ]
+    do
+      zc=`sudo cat /sys/kernel/debug/friend_loader/zero_clear`
+    done
+
     ./run.sh run
 
     trap './run.sh stop;' SIGINT


### PR DESCRIPTION
＊インターフェース説明
/---/friend_loader/zero_clearに対して
  - 書き込み
 zero_clearの値が0のとき自然数nを書き込むとToshokanの n *PAGE_SIZE のメモリ領域が0クリア
それ以外の書き込みは無視

  - 読み込み
0: 0クリアを行っていないとき
non-0: 0クリアを行っている時（そのとき書き込んでも無効）


＊実装方法
今までのsysfsカーネルモジュールを拡張，workqueueを用いて0クリア